### PR TITLE
fix: missing cache key in _fetch_organs and  _fetch_celltypes

### DIFF
--- a/Python/atlasapprox/__init__.py
+++ b/Python/atlasapprox/__init__.py
@@ -129,7 +129,7 @@ class API:
         """
         if ("organs" not in self.cache) or (organism not in self.cache["organs"]):
             _fetch_organs(self, organism, measurement_type)
-        return self.cache["organs"][organism]
+        return self.cache["organs"][(measurement_type, organism)]
 
     def celltypes(
         self,

--- a/Python/atlasapprox/utils.py
+++ b/Python/atlasapprox/utils.py
@@ -58,6 +58,6 @@ def _fetch_celltypes(api, organism: str, organ: str, measurement_type: str, incl
             }
             api.cache["celltypes"][(measurement_type, organism, organ, include_abundance)] = res
         else:
-            api.cache["celltypes"][(measurement_type, organ, include_abundance)] = response.json()["celltypes"]
+            api.cache["celltypes"][(measurement_type, organism, organ, include_abundance)] = response.json()["celltypes"]
     else:
         raise BadRequestError(response.json()["message"])


### PR DESCRIPTION
Hi Fabio,

The organs and celltypes API functions were causing errors due to missing cache keys (see attached). I’ve added the missing keys, and the functions are working correctly now.

Cheers
<img width="1252" alt="Screen Shot 2024-09-04 at 11 27 20 am" src="https://github.com/user-attachments/assets/1426f691-0f7b-4459-a8f9-85d8aab13952">
